### PR TITLE
Refactor methods to accept optionalParameters Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,26 @@ Executes the passed annotators and instantiates an instance of the Alvairum Java
 
 **`List<String> annotatorKinds`**: takes a list of annotator names identical to the format used in Alvarium configs that will be executed. The method will throw an error if there is no configuration entry for the annotator in the configuration file.
 
-**`String artifactPath`**: Optional parameter that is only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact. The current implementation expects an existing artifact checksum at "\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"
+**`Map<String,String> optionalParameters=[:]`**: Supports optional parameters (`artifactPath`, `checksumPath`, `sourceCodeChecksumPath`)
+
+`artifactPath`: Only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact.
+
+`checksumPath`: Used to locate the artifact checksum, default value if not provided is `"\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"`
+
+`sourceCodeChecksumPath`: Used to locate the source code checkusm, default value if not provided is `"${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"`
 
 ### **alvariumMutate(List<String> annotatorKinds, String artifactPath=null, byte[] newData)**
 Executes the passed annotators and instantiates an instance of the Alvairum Java SDK to publish them using the `Sdk.mutate()` method and sets the source annotation (represents lineage) key as the string `{pipelineID}/{buildNo}` and the new data key using `byte[] newData`. This method is usually called after an artifact is created with annotators relating to artifact verification.
 
 **`List<String> annotatorKinds`**: takes a list of annotator names identical to the format used in Alvarium configs that will be executed. The method will throw an error if there is no configuration entry for the annotator in the configuration file.
 
-**`String artifactPath`**: Optional parameter that is only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact. The current implementation expects an existing artifact checksum at "\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"
+**`Map<String,String> optionalParameters=[:]`**: Supports optional parameters (`artifactPath`, `checksumPath`, `sourceCodeChecksumPath`)
+
+`artifactPath`: Only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact.
+
+`checksumPath`: Used to locate the artifact checksum, default value if not provided is `"\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"`
+
+`sourceCodeChecksumPath`: Used to locate the source code checkusm, default value if not provided is `"${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"`
 
 **`String newData`**: Used to define a new key for the annotations. This is usually a unique identifier for the artifact being produced by the pipeline (i.e., checksum or tag).
 
@@ -110,7 +122,13 @@ Executes the passed annotators and instantiates an instance of the Alvairum Java
 
 **`List<String> annotatorKinds`**: takes a list of annotator names identical to the format used in Alvarium configs that will be executed. The method will throw an error if there is no configuration entry for the annotator in the configuration file.
 
-**`String artifactPath`**: Optional parameter that is only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact. The current implementation expects an existing artifact checksum at "\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"
+**`Map<String,String> optionalParameters=[:]`**: Supports optional parameters (`artifactPath`, `checksumPath`, `sourceCodeChecksumPath`)
+
+`artifactPath`: Only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact.
+
+`checksumPath`: Used to locate the artifact checksum, default value if not provided is `"\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"`
+
+`sourceCodeChecksumPath`: Used to locate the source code checkusm, default value if not provided is `"${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"`
 
 Here is an example Jenkinsfile that can be used to build the alvarium Java SDK
 
@@ -177,7 +195,11 @@ pipeline {
                     // TODO (Ali Amin): Find a way to persist the checksum
                     script {
                         def artifactChecksum = readFile "/${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/alvarium-sdk-1.0-SNAPSHOT.jar.checksum" 
-                        alvariumMutate(['checksum'], '${WORKSPACE}/target/alvarium-sdk-1.0-SNAPSHOT.jar', artifactChecksum.bytes)
+                        def optionalParameters = [
+                          'artifactPath' :'${WORKSPACE}/target/alvarium-sdk-1.0-SNAPSHOT.jar',
+                          'checksumPath' : '/${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/alvarium-sdk-1.0-SNAPSHOT.jar.checksum'
+                        ]
+                        alvariumMutate(['checksum'], optionalParameters, artifactChecksum.bytes)
                     }   
                 }
             }

--- a/vars/alvariumCreate.groovy
+++ b/vars/alvariumCreate.groovy
@@ -13,10 +13,16 @@ import com.alvarium.SdkInfo;
 import com.alvarium.annotators.Annotator;
 import com.alvarium.utils.PropertyBag;
 
-def call(List<String> annotatorKinds, String artifactPath=null) {
+def call(List<String> annotatorKinds, Map<String,String> optionalParameters=[:]) {
+    String artifactPath = optionalParameters['artifactPath'] ? optionalParameters['artifactPath'] : null
+    String checksumPath
+    String sourceCodeChecksumPath = optionalParameters['sourceCodeChecksumPath'] ? optionalParameters['sourceCodeChecksumPath'] : "${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"
 
-    if (annotatorKinds.contains('checksum') && artifactPath == null) {
-        error "Checksum annotator requires the `artifactPath` parameter"
+    if (annotatorKinds.contains('checksum')) {
+        if(artifactPath == null){
+        error "Checksum annotator requires the `artifactPath` in optionalParameters"
+        }
+        checksumPath = optionalParameters['checksumPath'] ? optionalParameters['checksumPath'] : "${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/${new File(artifactPath).getName()}.checksum"
     }
 
     Logger logger = LogManager.getRootLogger()
@@ -36,6 +42,8 @@ def call(List<String> annotatorKinds, String artifactPath=null) {
     def (Annotator[] annotators, PropertyBag ctx) = alvariumGetAnnotators(
         annotatorKinds,
         artifactPath,
+        checksumPath,
+        sourceCodeChecksumPath,
         sdkInfo,
         logger    
     )

--- a/vars/alvariumGetAnnotators.groovy
+++ b/vars/alvariumGetAnnotators.groovy
@@ -23,7 +23,9 @@ import com.alvarium.utils.ImmutablePropertyBag;
 
 def call(
     List<String> annotatorKinds,
-    String artifactPath=null,
+    String artifactPath,
+    String checksumPath,
+    String sourceCodeChecksumPath,
     SdkInfo sdkInfo,
     Logger logger
 ) {
@@ -39,7 +41,7 @@ def call(
             case "checksum":
                 File artifact = new File(artifactPath);
                 File checksum = new File(
-                    "${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/${artifact.getName()}.checksum"
+                    checksumPath
                 )
                 ChecksumAnnotatorProps props = new ChecksumAnnotatorProps(
                     artifactPath,
@@ -54,7 +56,7 @@ def call(
                 annotator = annotatorFactory.getAnnotator(cfg, sdkInfo, logger)
                 SourceCodeAnnotatorProps props = new SourceCodeAnnotatorProps(
                     "${WORKSPACE}",
-                    "${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"
+                    sourceCodeChecksumPath
                 )
                 properties.put(AnnotationType.SourceCode.name(), props)
                 annotators.add(annotator)

--- a/vars/alvariumMutate.groovy
+++ b/vars/alvariumMutate.groovy
@@ -13,10 +13,16 @@ import com.alvarium.SdkInfo;
 import com.alvarium.annotators.Annotator;
 import com.alvarium.utils.PropertyBag;
 
-def call(List<String> annotatorKinds, String artifactPath=null, byte[] newData) {
-    
-    if (annotatorKinds.contains('checksum') && artifactPath == null) {
-        error "Checksum annotator requires the `artifactPath` parameter"
+def call(List<String> annotatorKinds, Map<String,String> optionalParameters=[:], byte[] newData) {
+    String artifactPath = optionalParameters['artifactPath'] ? optionalParameters['artifactPath'] : null
+    String checksumPath
+    String sourceCodeChecksumPath = optionalParameters['sourceCodeChecksumPath'] ? optionalParameters['sourceCodeChecksumPath'] : "${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"
+
+    if (annotatorKinds.contains('checksum')) {
+        if(artifactPath == null){
+        error "Checksum annotator requires the `artifactPath` in optionalParameters"
+        }
+        checksumPath = optionalParameters['checksumPath'] ? optionalParameters['checksumPath'] : "${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/${new File(artifactPath).getName()}.checksum"
     }
     
     Logger logger = LogManager.getRootLogger()
@@ -36,6 +42,8 @@ def call(List<String> annotatorKinds, String artifactPath=null, byte[] newData) 
     def (Annotator[] annotators, PropertyBag ctx) = alvariumGetAnnotators(
         annotatorKinds,
         artifactPath,
+        checksumPath,
+        sourceCodeChecksumPath,
         sdkInfo,
         logger    
     )

--- a/vars/alvariumTransit.groovy
+++ b/vars/alvariumTransit.groovy
@@ -13,10 +13,16 @@ import com.alvarium.SdkInfo;
 import com.alvarium.annotators.Annotator;
 import com.alvarium.utils.PropertyBag;
 
-def call(List<String> annotatorKinds, String artifactPath=null) {
+def call(List<String> annotatorKinds, Map<String,String> optionalParameters=[:]) {
+    String artifactPath = optionalParameters['artifactPath'] ? optionalParameters['artifactPath'] : null
+    String checksumPath
+    String sourceCodeChecksumPath = optionalParameters['sourceCodeChecksumPath'] ? optionalParameters['sourceCodeChecksumPath'] : "${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"
 
-    if (annotatorKinds.contains('checksum') && artifactPath == null) {
-        error "Checksum annotator requires the `artifactPath` parameter"
+    if (annotatorKinds.contains('checksum')) {
+        if(artifactPath == null){
+        error "Checksum annotator requires the `artifactPath` in optionalParameters"
+        }
+        checksumPath = optionalParameters['checksumPath'] ? optionalParameters['checksumPath'] : "${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/${new File(artifactPath).getName()}.checksum"
     }
 
     Logger logger = LogManager.getRootLogger()
@@ -36,6 +42,8 @@ def call(List<String> annotatorKinds, String artifactPath=null) {
     def (Annotator[] annotators, PropertyBag ctx) = alvariumGetAnnotators(
         annotatorKinds,
         artifactPath,
+        checksumPath,
+        sourceCodeChecksumPath,
         sdkInfo,
         logger    
     )


### PR DESCRIPTION
Fix #1
Fix #2 

- Refactored alvariumCreate, alvariumTransit, alvariumMutate to accept `Map<String,String> optionalParameters` instead of  `String artifactPath`.
- The artifcatPath, checksumPath and sourceCodeChecksumPath is extracted from the Map. If (checksumPath or sourceCodeChecksumPath) is not provided they're set with the default values below.
- Refactored alvariumGetAnnotators to accept checksumPath and sourceCodeChecksumPath.



**`Map<String,String> optionalParameters=[:]`**: Supports optional parameters (`artifactPath`, `checksumPath`, `sourceCodeChecksumPath`)

`artifactPath`: Only required when "checksum" annotator is passed in the `annotatorKinds` list and will throw an error if not present when required by the "checksum" annotator. This parameter is used to locate the artifact.

`checksumPath`: Used to locate the artifact checksum, default value if not provided is `"\${JENKINS_HOME}/jobs/\${JOB_NAME}/\${BUILD_NUMBER}/\${artifactName}.checksum"`

`sourceCodeChecksumPath`: Used to locate the source code checkusm, default value if not provided is `"${JENKINS_HOME}/${JOB_NAME}/${BUILD_NUMBER}/checksum"`

Example:
```groovy
 script {
             def artifactChecksum = readFile "/${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/alvarium-sdk-1.0-SNAPSHOT.jar.checksum" 
             def optionalParameters = [
               'artifactPath' :'${WORKSPACE}/target/alvarium-sdk-1.0-SNAPSHOT.jar',
               'checksumPath' : '/${JENKINS_HOME}/jobs/${JOB_NAME}/${BUILD_NUMBER}/alvarium-sdk-1.0-SNAPSHOT.jar.checksum'
               ]
             alvariumMutate(['checksum'], optionalParameters, artifactChecksum.bytes)
         }   
``` 